### PR TITLE
Possibility to make custom cache key generation strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,31 @@ class MyService {
 }
 ```
 
+Cache decorator generates cache key according to class name, class method and args (with JSON.stringify).
+If you want another key creation logic you can bypass key creation strategy to the Cache decorator.
+
+```ts
+import { Cache, ExpirationStrategy, MemoryStorage, IKeyStrategy } from "node-ts-cache";
+
+class MyKeyStrategy implements IKeyStrategy {
+   public getKey(className: string, methodName: string, args: any[]): Promise<string> | string {
+        // Here you can implement your own way of creating cache keys
+        return `foo bar baz`;
+   }
+}
+
+const myStrategy = new ExpirationStrategy(new MemoryStorage());
+const myKeyStrategy = new MyKeyStrategy();
+
+class MyService {
+    
+    @Cache(myStrategy, myKeyStrategy, { ttl: 60 })
+    public async getUsers(): Promise<string[]> {
+        return ["Max", "User"];
+    }
+}
+```
+
 ## Directly
 ```ts
 import { ExpirationStrategy, MemoryStorage } from "node-ts-cache";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts-cache",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,48 +5,57 @@
   "requires": true,
   "dependencies": {
     "@sinonjs/commons": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
-      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
       }
     },
     "@sinonjs/formatio": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
-      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/samsam": "^2 || ^3"
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
       }
     },
     "@sinonjs/samsam": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.0.2.tgz",
-      "integrity": "sha512-m08g4CS3J6lwRQk1pj1EO+KEVWbrbXsmi9Pw0ySmrIbcVxVaedoFgLvFsV8wHLwh01EpROVz3KvVcD1Jmks9FQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/commons": "^1.3.0",
         "array-from": "^2.1.1",
-        "lodash.get": "^4.4.2"
+        "lodash": "^4.17.15"
       }
     },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/bluebird": {
-      "version": "3.5.24",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.24.tgz",
-      "integrity": "sha512-YeQoDpq4Lm8ppSBqAnAeF/xy1cYp/dMTif2JFcvmAbETMRlvKHT2iLcWu+WyYiJO3b3Ivokwo7EQca/xfLVJmg=="
+      "version": "3.5.27",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.27.tgz",
+      "integrity": "sha512-6BmYWSBea18+tSjjSC3QIyV93ZKAeNWGM7R6aYt1ryTZXrlHF+QLV0G2yV0viEGVyRkyQsWfMoJ0k/YghBX5sQ==",
+      "dev": true
     },
     "@types/mocha": {
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
-      "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww=="
+      "integrity": "sha512-lAVp+Kj54ui/vLUFxsJTMtWvZraZxum3w3Nwkble2dNuV5VnPA+Mi2oGX9XYJAaIvZi3tn3cbjS/qcJXRb6Bww==",
+      "dev": true
     },
     "@types/node": {
-      "version": "10.12.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.9.tgz",
-      "integrity": "sha512-eajkMXG812/w3w4a1OcBlaTwsFPO5F7fJ/amy+tieQxEMWBlbV1JGSjkFM+zkHNf81Cad+dfIRA+IBkvmvdAeA=="
+      "version": "10.14.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.17.tgz",
+      "integrity": "sha512-p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ=="
     },
     "@types/proxyquire": {
       "version": "1.3.28",
@@ -55,9 +64,10 @@
       "dev": true
     },
     "@types/redis": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.8.tgz",
-      "integrity": "sha512-o/1ufNVPA92uum9HFbEiXXIHBuLywSwHQtAZoACMc1FhPXS5YftybBC1EI0zjdbUb273VVWF0Ivll/bq4g+gyw==",
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.13.tgz",
+      "integrity": "sha512-p86cm5P6DMotUqCS6odQRz0JJwc5QXZw9eyH0ALVIqmq12yqtex5ighWyGFHKxak9vaA/GF/Ilu0KZ0MuXXUbg==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -68,16 +78,16 @@
       "integrity": "sha512-Wnuv66VhvAD2LEJfZkq8jowXGxe+gjVibeLCYcVBp7QLdw0BFx2sRkKzoiiDkYEPGg5VyqO805Rcj0stVjQwCQ==",
       "dev": true
     },
+    "arg": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+      "dev": true
+    },
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
       "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "balanced-match": {
@@ -87,9 +97,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -228,16 +238,16 @@
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lolex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
-      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
     },
     "make-error": {
@@ -308,24 +318,16 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
-      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^2.3.2",
-        "path-to-regexp": "^1.7.0",
-        "text-encoding": "^0.6.4"
-      },
-      "dependencies": {
-        "lolex": {
-          "version": "2.7.5",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
-          "dev": true
-        }
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
       }
     },
     "once": {
@@ -359,37 +361,37 @@
       }
     },
     "proxyquire": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.0.tgz",
-      "integrity": "sha512-kptdFArCfGRtQFv3Qwjr10lwbEV0TBJYvfqzhwucyfEXqVgmnAkyEw/S3FYzR5HI9i5QOq4rcqQjZ6AlknlCDQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
+      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
       "dev": true,
       "requires": {
         "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.0",
-        "resolve": "~1.8.1"
+        "module-not-found-error": "^1.0.1",
+        "resolve": "^1.11.1"
       }
     },
     "resolve": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "^1.0.6"
       }
     },
     "sinon": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.2.tgz",
-      "integrity": "sha512-WLagdMHiEsrRmee3jr6IIDntOF4kbI6N2pfbi8wkv50qaUQcBglkzkjtoOEbeJ2vf1EsrHhLI+5Ny8//WHdMoA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.4.2.tgz",
+      "integrity": "sha512-pY5RY99DKelU3pjNxcWo6XqeB1S118GBcVIIdDi6V+h6hevn1izcg2xv1hTHW/sViRXU7sUOxt4wTUJ3gsW2CQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.2.0",
-        "@sinonjs/formatio": "^3.1.0",
-        "@sinonjs/samsam": "^3.0.2",
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
         "diff": "^3.5.0",
-        "lolex": "^3.0.0",
-        "nise": "^1.4.7",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
         "supports-color": "^5.5.0"
       },
       "dependencies": {
@@ -411,9 +413,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -429,32 +431,23 @@
         "has-flag": "^3.0.0"
       }
     },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
-      "dev": true
-    },
     "ts-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
+      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.0",
-        "buffer-from": "^1.1.0",
-        "diff": "^3.1.0",
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
         "source-map-support": "^0.5.6",
-        "yn": "^2.0.0"
+        "yn": "^3.0.0"
       },
       "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
           "dev": true
         }
       }
@@ -466,9 +459,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
+      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
       "dev": true
     },
     "wrappy": {
@@ -478,9 +471,9 @@
       "dev": true
     },
     "yn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts-cache",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts-cache",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Simple and extensible caching module supporting decorators",
   "main": "src/index.js",
   "scripts": {
@@ -40,20 +40,20 @@
   },
   "homepage": "https://github.com/havsar/node-ts-cache#readme",
   "dependencies": {
-    "@types/bluebird": "3.5.24",
-    "@types/mocha": "5.2.5",
-    "@types/node": "10.12.9",
-    "@types/redis": "^2.8.8",
-    "bluebird": "3.5.3"
+    "@types/bluebird": "3.5.27",
+    "@types/node": "10.14.17",
+    "@types/redis": "^2.8.13",
+    "bluebird": "3.5.5"
   },
   "devDependencies": {
-    "@types/proxyquire": "^1.3.28",
-    "@types/sinon": "^5.0.5",
+    "@types/mocha": "5.2.5",
+    "@types/proxyquire": "1.3.28",
+    "@types/sinon": "5.0.5",
     "mocha": "5.2.0",
-    "proxyquire": "^2.1.0",
-    "sinon": "^7.2.2",
-    "ts-node": "7.0.1",
-    "typescript": "3.1.6"
+    "proxyquire": "2.1.3",
+    "sinon": "7.4.2",
+    "ts-node": "8.3.0",
+    "typescript": "3.6.2"
   },
   "optionalDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts-cache",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Simple and extensible caching module supporting decorators",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ts-cache",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Simple and extensible caching module supporting decorators",
   "main": "src/index.js",
   "scripts": {

--- a/src/CacheDecorator.spec.ts
+++ b/src/CacheDecorator.spec.ts
@@ -1,5 +1,5 @@
 import { MemoryStorage } from './storages/MemoryStorage';
-import { ExpirationStrategy } from './strategies/ExpirationStrategy';
+import { ExpirationStrategy } from './strategies/caching/ExpirationStrategy';
 import * as Assert from 'assert';
 import { Cache } from './CacheDecorator';
 

--- a/src/CacheDecorator.ts
+++ b/src/CacheDecorator.ts
@@ -1,12 +1,37 @@
-import { AbstractBaseStrategy } from './strategies/AbstractBaseStrategy';
+import { AbstractBaseStrategy } from './strategies/caching/AbstractBaseStrategy';
+import {AbstractBaseKeyStrategy} from './strategies/key/AbstractBaseStrategy';
+import {JSONStringifyStrategy} from './strategies/key/JSONStringifyStrategy';
 
-export function Cache(cachingStrategy: AbstractBaseStrategy, options: any): Function {
+const DefaultKeyStrategy = JSONStringifyStrategy;
+
+function Cache(cachingStrategy: AbstractBaseStrategy, options: any): Function;
+function Cache(
+    cachingStrategy: AbstractBaseStrategy,
+    keyStrategy: AbstractBaseKeyStrategy,
+    options: any
+): Function;
+function Cache(
+    ...args: any[]
+): Function {
     return function (target: any, methodName: string, descriptor: PropertyDescriptor) {
+        const cachingStrategy = args[0];
+
+        let keyStrategy: AbstractBaseKeyStrategy;
+        let options: any;
+
+        if (args[1] instanceof AbstractBaseKeyStrategy) {
+            keyStrategy = args[1];
+            options = args[2];
+        } else {
+            keyStrategy = new DefaultKeyStrategy();
+            options = args[1];
+        }
+
         const originalMethod = descriptor.value;
         const className = target.constructor.name;
 
         descriptor.value = async function (...args: any[]) {
-            const cacheKey = `${className}:${methodName}:${JSON.stringify(args)}`;
+            const cacheKey = await keyStrategy.getKey(className, methodName, args);
 
             const entry = await cachingStrategy.getItem(cacheKey);
             if (entry) {
@@ -28,3 +53,5 @@ export function Cache(cachingStrategy: AbstractBaseStrategy, options: any): Func
         return descriptor;
     };
 }
+
+export {Cache};

--- a/src/CacheDecorator.ts
+++ b/src/CacheDecorator.ts
@@ -1,13 +1,13 @@
 import { AbstractBaseStrategy } from './strategies/caching/AbstractBaseStrategy';
-import {AbstractBaseKeyStrategy} from './strategies/key/AbstractBaseStrategy';
-import {JSONStringifyStrategy} from './strategies/key/JSONStringifyStrategy';
+import { JSONStringifyKeyStrategy } from './strategies/key/JSONStringifyStrategy';
+import { IKeyStrategy } from './strategies/key/IKeyStrategy';
 
-const DefaultKeyStrategy = JSONStringifyStrategy;
+const DefaultKeyStrategy = JSONStringifyKeyStrategy;
 
 function Cache(cachingStrategy: AbstractBaseStrategy, options: any): Function;
 function Cache(
     cachingStrategy: AbstractBaseStrategy,
-    keyStrategy: AbstractBaseKeyStrategy,
+    keyStrategy: IKeyStrategy,
     options: any
 ): Function;
 function Cache(
@@ -16,10 +16,10 @@ function Cache(
     return function (target: any, methodName: string, descriptor: PropertyDescriptor) {
         const cachingStrategy = args[0];
 
-        let keyStrategy: AbstractBaseKeyStrategy;
+        let keyStrategy: IKeyStrategy;
         let options: any;
 
-        if (args[1] instanceof AbstractBaseKeyStrategy) {
+        if (args[1].getKey) {
             keyStrategy = args[1];
             options = args[2];
         } else {
@@ -54,4 +54,4 @@ function Cache(
     };
 }
 
-export {Cache};
+export { Cache };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {FsJsonStorage} from './storages/FsJsonStorage';
 import {MemoryStorage} from './storages/MemoryStorage';
 import {ExpirationStrategy} from './strategies/caching/ExpirationStrategy';
 import {Cache} from './CacheDecorator';
+import {IKeyStrategy} from './strategies/key/IKeyStrategy';
+import {ICacheStrategy} from './strategies/caching/ICacheStrategy';
 
-
-export {Cache, ExpirationStrategy, MemoryStorage, FsJsonStorage, RedisStorage};
+export {Cache, ExpirationStrategy, MemoryStorage, FsJsonStorage, RedisStorage, IKeyStrategy, ICacheStrategy};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import {RedisStorage} from './storages/RedisStorage';
 import {FsJsonStorage} from './storages/FsJsonStorage';
 import {MemoryStorage} from './storages/MemoryStorage';
-import {ExpirationStrategy} from './strategies/ExpirationStrategy';
+import {ExpirationStrategy} from './strategies/caching/ExpirationStrategy';
 import {Cache} from './CacheDecorator';
+
 
 export {Cache, ExpirationStrategy, MemoryStorage, FsJsonStorage, RedisStorage};

--- a/src/strategies/caching/AbstractBaseStrategy.ts
+++ b/src/strategies/caching/AbstractBaseStrategy.ts
@@ -1,6 +1,7 @@
 import { IStorage } from '../../storages/IStorage';
+import { ICacheStrategy } from './ICacheStrategy';
 
-export abstract class AbstractBaseStrategy {
+export abstract class AbstractBaseStrategy implements ICacheStrategy {
 
     constructor(protected storage: IStorage) { }
 

--- a/src/strategies/caching/AbstractBaseStrategy.ts
+++ b/src/strategies/caching/AbstractBaseStrategy.ts
@@ -1,4 +1,4 @@
-import { IStorage } from '../storages/IStorage';
+import { IStorage } from '../../storages/IStorage';
 
 export abstract class AbstractBaseStrategy {
 

--- a/src/strategies/caching/ExpirationStrategy.spec.ts
+++ b/src/strategies/caching/ExpirationStrategy.spec.ts
@@ -1,4 +1,4 @@
-import {MemoryStorage} from '../storages/MemoryStorage';
+import {MemoryStorage} from '../../storages/MemoryStorage';
 import * as Assert from "assert";
 import {ExpirationStrategy} from './ExpirationStrategy';
 

--- a/src/strategies/caching/ExpirationStrategy.ts
+++ b/src/strategies/caching/ExpirationStrategy.ts
@@ -1,4 +1,4 @@
-import { IStorage } from '../storages/IStorage';
+import { IStorage } from '../../storages/IStorage';
 import { AbstractBaseStrategy } from './AbstractBaseStrategy';
 
 interface IExpiringCacheItem {

--- a/src/strategies/caching/ICacheStrategy.ts
+++ b/src/strategies/caching/ICacheStrategy.ts
@@ -1,0 +1,5 @@
+export interface ICacheStrategy {
+    getItem<T>(key: string): Promise<T>;
+    setItem(key: string, content: any, options: any): Promise<void>;
+    clear(): Promise<void>;
+}

--- a/src/strategies/key/AbstractBaseStrategy.ts
+++ b/src/strategies/key/AbstractBaseStrategy.ts
@@ -1,5 +1,0 @@
-export abstract class AbstractBaseKeyStrategy {
-    constructor() {}
-
-    public abstract getKey(className: string, methodName: string, args: any[]): Promise<string> | string;
-}

--- a/src/strategies/key/AbstractBaseStrategy.ts
+++ b/src/strategies/key/AbstractBaseStrategy.ts
@@ -1,0 +1,5 @@
+export abstract class AbstractBaseKeyStrategy {
+    constructor() {}
+
+    public abstract getKey(className: string, methodName: string, args: any[]): Promise<string> | string;
+}

--- a/src/strategies/key/IKeyStrategy.ts
+++ b/src/strategies/key/IKeyStrategy.ts
@@ -1,0 +1,3 @@
+export interface IKeyStrategy {
+    getKey(className: string, methodName: string, args: any[]): Promise<string> | string;
+}

--- a/src/strategies/key/JSONStringifyStrategy.ts
+++ b/src/strategies/key/JSONStringifyStrategy.ts
@@ -1,6 +1,6 @@
-import {AbstractBaseKeyStrategy} from './AbstractBaseStrategy';
+import { IKeyStrategy } from './IKeyStrategy';
 
-export class JSONStringifyStrategy extends AbstractBaseKeyStrategy {
+export class JSONStringifyKeyStrategy implements IKeyStrategy {
     public getKey(className: string, methodName: string, args: any[]): Promise<string> | string {
         return `${className}:${methodName}:${JSON.stringify(args)}`;
     }

--- a/src/strategies/key/JSONStringifyStrategy.ts
+++ b/src/strategies/key/JSONStringifyStrategy.ts
@@ -1,0 +1,7 @@
+import {AbstractBaseKeyStrategy} from './AbstractBaseStrategy';
+
+export class JSONStringifyStrategy extends AbstractBaseKeyStrategy {
+    public getKey(className: string, methodName: string, args: any[]): Promise<string> | string {
+        return `${className}:${methodName}:${JSON.stringify(args)}`;
+    }
+}


### PR DESCRIPTION
Hello!

We are using your library in production and it works great, so thank you very much.

But in some cases default cache key creating strategy is not great. JSON stringify can throw error on complex recursive objects. Also at the highload JSON.stringify can be a bottleneck and we need to use some alternatives (for example https://github.com/ibmruntimes/yieldable-json). 

So i made a possibility to bypass custom key generation strategy. Also added some interfaces, tests and added new possibility to docs.