### PR TITLE
Enable Typescript strict mode

### DIFF
--- a/src/storage/redis.storage.ts
+++ b/src/storage/redis.storage.ts
@@ -16,7 +16,7 @@ export class RedisStorage implements StorageTypes {
     }
 
     public async getItem<T>(key: string): Promise<T> {
-        const entry: any = await this.client.getAsync(key)
+        const entry: any = await this.client.getAsync!(key)
         let finalItem = entry
         try {
             finalItem = JSON.parse(entry)
@@ -29,12 +29,12 @@ export class RedisStorage implements StorageTypes {
         if (typeof content === 'object') {
             content = JSON.stringify(content)
         } else if (content === undefined) {
-            return this.client.delAsync(key)
+            return this.client.delAsync!(key)
         }
-        return this.client.setAsync(key, content)
+        return this.client.setAsync!(key, content)
     }
 
     public async clear(): Promise<void> {
-        return this.client.flushdbAsync()
+        return this.client.flushdbAsync!()
     }
 }

--- a/src/storage/storage.types.ts
+++ b/src/storage/storage.types.ts
@@ -6,7 +6,7 @@ interface ICacheEntry {
 export interface StorageTypes {
     getItem<T>(key: string): Promise<T>;
 
-    setItem(key: string, content: ICacheEntry): Promise<void>;
+    setItem(key: string, content?: ICacheEntry): Promise<void>;
 
     clear(): Promise<void>;
 }

--- a/src/strategy/caching/abstract.base.strategy.ts
+++ b/src/strategy/caching/abstract.base.strategy.ts
@@ -6,7 +6,7 @@ export abstract class AbstractBaseStrategy implements ICacheStrategy {
     constructor(protected storage: StorageTypes) {
     }
 
-    public async abstract getItem<T>(key: string): Promise<T>;
+    public async abstract getItem<T>(key: string): Promise<T | undefined>;
 
     public async abstract setItem(key: string, content: any, options: any): Promise<void>;
 

--- a/src/strategy/caching/cache.strategy.types.ts
+++ b/src/strategy/caching/cache.strategy.types.ts
@@ -1,5 +1,5 @@
 export interface ICacheStrategy {
-    getItem<T>(key: string): Promise<T>;
+    getItem<T>(key: string): Promise<T | undefined>;
 
     setItem(key: string, content: any, options: any): Promise<void>;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "emitDecoratorMetadata": true,
+    "strict": true,
     "lib": [
       "es2015"
     ],


### PR DESCRIPTION
## Context:

Issue #13 and the helpful comments pointed this problem out already: because this library is published as Typescript (not just types and compiled js), the source of this library is compiled within the parent project. When using this library in a typescript project with `strict: true` enabled in tsconfig.json, the strict-mode failures inside the library cause the build to fail. I'm not a Typescript expert, but the strict mode failures seem to fall into two classes:
* Objects that are incorrectly detected as potentially undefined. We can use `!` to assert that these are not undefined, which satisfies the type checker.
* Arguments and return types that can be undefined but are not explicitly declared as such. We can use the `?` operator (and `Foo | undefined` for return types) to make these explicit.

## Changes:

* Enable strict mode in tsconfig.json

Fix the following strict-mode violations:

### Be explicit about optional types - *Breaking Changes in the API*
* `StorageTypes.setItem` can take content = undefined, so use `?` operator
* `ICacheStrategy.getItem` can return undefined, so make the return type
  `Promise<T | undefined>` (and in all the sub-types) 

### Add assertions that objects are not undefined when that is safe (internal-only changes)
* `RedisStorage.client` is picked up as potentially being undefined, but it
  is set in the constructor, so use the `!` operator to assert non-null.
* In `ExpirationStrategy`, `options.ttl` is being detected as potentially undefined,
  but there is a default of 60s. Make that default more explicit to silence the
  warning.

I repeat: I'm not a Typescript expert, I'd appreciate any feedback on nuances I'm missing here.