### PR TITLE
storage-node-fs with string parameter

### DIFF
--- a/packages/core/src/decorator/cache-decorator.ts
+++ b/packages/core/src/decorator/cache-decorator.ts
@@ -8,7 +8,7 @@ const jsonCalculateKey = (data: {
     methodName: string
     args: any[]
 }) => {
-    return `${data.className}:${<string>data.methodName}:${JSON.stringify(
+    return `${data.className}--${<string>data.methodName}--${JSON.stringify(
         data.args
     )}`
 }


### PR DESCRIPTION
Fix #27 

In the cache key generator the symbol `:` didn't work with JSON.parse

Use cache key with
```
`${data.className}--${data.methodName}--${JSON.stringify(data.args)}`
```

@havsar the main problem for change the cache key is we are forcing to invalidate the existing cache keys and I not sure how impact in the Redis or memory storages.