### PR TITLE
adding capability to clone cache items when retrieving from cache.

### DIFF
--- a/packages/storage-memory/src/index.ts
+++ b/packages/storage-memory/src/index.ts
@@ -15,7 +15,8 @@ export class MemoryStorage implements IStorage {
     public async getItem(key: string): Promise<ICacheItem | undefined> {
         let response;
         if(this.shouldClone){
-            response = JSON.parse(JSON.stringify(this.memCache[key]));
+            const cacheData = this.memCache[key];
+            response = cacheData?JSON.parse(JSON.stringify(this.memCache[key])):cacheData;
         }else{
             response = this.memCache[key]
         }

--- a/packages/storage-memory/src/index.ts
+++ b/packages/storage-memory/src/index.ts
@@ -1,12 +1,25 @@
 import { ICacheItem, IStorage } from "node-ts-cache"
+import { IMemoryCacheOptions } from "./memory-types"
+export * from "./memory-types"
 
 export class MemoryStorage implements IStorage {
     private memCache: any = {}
+    private shouldClone: boolean = false; // by default no cloning (default behaviour)
 
-    constructor() {}
+    constructor(options?:IMemoryCacheOptions) {
+        if(options){
+            this.shouldClone = options.clone
+        }
+    }
 
     public async getItem(key: string): Promise<ICacheItem | undefined> {
-        return this.memCache[key]
+        let response;
+        if(this.shouldClone){
+            response = JSON.parse(JSON.stringify(this.memCache[key]));
+        }else{
+            response = this.memCache[key]
+        }
+        return response;
     }
 
     public async setItem(key: string, content: any): Promise<void> {

--- a/packages/storage-memory/src/memory-types.ts
+++ b/packages/storage-memory/src/memory-types.ts
@@ -1,0 +1,3 @@
+export interface IMemoryCacheOptions {
+    clone: boolean // when set to true data returned from cache will be deep copied (deep copy will be returned)
+}


### PR DESCRIPTION
When annotating method calls with memory cache it seems reasonable to allow to receive individual copies so eventuall modifications of cache item are not affecting the actual cache item.